### PR TITLE
Fix missing transform for Olya

### DIFF
--- a/script.rpy
+++ b/script.rpy
@@ -12,6 +12,10 @@ transform slide_from_right:
     xalign 1.5
     linear 0.5 xalign 1.0
 
+transform slide_left_to_center:
+    xalign -0.5
+    linear 0.5 xalign 0.5
+
 label start:
     scene bg school_day with fade
 


### PR DESCRIPTION
## Summary
- add `slide_left_to_center` transform so Olya can slide to the middle of the screen

## Testing
- `renpy --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684446df59dc8325a8300e517745ca3b